### PR TITLE
Update repo-identification.yml

### DIFF
--- a/.github/workflows/repo-identification.yml
+++ b/.github/workflows/repo-identification.yml
@@ -2,6 +2,10 @@ name: Workflow on change to repo-identification.yaml workflow
 on:
   workflow_dispatch:
 
+  push:
+    paths:
+      - '.github/workflows/repo-identification.yaml'
+
 jobs:
   myJob:
     runs-on: ubuntu-latest
@@ -11,4 +15,4 @@ jobs:
 
       - name: Run some task for testing
         run: |
-          echo "This workflow was changed again..."
+          echo "This workflow was changed"


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/repo-identification.yml` file to modify the workflow trigger and update a task message. 

* [`.github/workflows/repo-identification.yml`](diffhunk://#diff-fc4d932a55a40d14b5277363a37a13d2c4bdc3e8a1b0472213c8935f782927abR5-R8): The workflow is now also triggered on push events that change the `.github/workflows/repo-identification.yaml` file. This ensures that the workflow is executed whenever there are modifications to its own configuration.
* [`.github/workflows/repo-identification.yml`](diffhunk://#diff-fc4d932a55a40d14b5277363a37a13d2c4bdc3e8a1b0472213c8935f782927abL14-R18): The message echoed by the task "Run some task for testing" has been changed from "This workflow was changed again..." to "This workflow was changed". This could be a simple message update or might be reflecting the new state of the workflow.